### PR TITLE
Shareable Link/Button for dashboard (read description for problem)

### DIFF
--- a/src/app/api/dataset/hazard/route.ts
+++ b/src/app/api/dataset/hazard/route.ts
@@ -13,3 +13,28 @@ export async function POST(request: NextRequest) {
     
     return NextResponse.json(countyData)
 }
+
+export async function GET(request: NextRequest) {
+    const searchParams = request.nextUrl.searchParams
+    const fips = searchParams.get("fips")
+
+    if (!fips) {
+        return NextResponse.json(
+            { error: "Missing FIPS code" },
+            { status: 400 }
+        )
+    }
+
+    const countyData = await db.query.hazard.findFirst({
+        where: eq(hazard.stateCountyFipsCode, fips),
+    })
+
+    if (!countyData) {
+        return NextResponse.json(
+            { error: "County not found" },
+            { status: 404 }
+        ) 
+    }
+    
+    return NextResponse.json(countyData)
+}


### PR DESCRIPTION
I was working on adding the shareable link functionality. A bit of this is still hard-coded, but Im still running into some issues. Now when a place is selected or searched, the url at the top updates with the fips code. I put a button for a shareable link that copies the link to the clipboard. The only problem is that when I use the link, the side panel with data and information gets loaded correctly (county and everything), but the map doesn't update. I have tried different variations where I use in the fips code in the url to try to render the map in the case that the url already has a fips code, but I ran into problems where it either did not work, or it would only work temporarily and go back to a default map. If someone wants to take a look, Im trying to find out a way so that the map also updates based on a given link/Url. Attached below are images of how this looks so far (the image where the map is default but the side panel is loaded is the current result of using the link).
<img width="378" alt="workingbutton1" src="https://github.com/user-attachments/assets/a752a735-320e-4ead-91f1-8d354b7ad3ad" />
<img width="945" alt="workingbutton2" src="https://github.com/user-attachments/assets/2c26d810-60af-4060-b8f7-2639823cfca5" />
<img width="949" alt="workingbutton3" src="https://github.com/user-attachments/assets/9d847387-5d54-4a92-8021-c2f5ea32f655" />
