### PR TITLE
the three pages under agreement filled out with template info

### DIFF
--- a/src/app/AccessibilityStatement/page.tsx
+++ b/src/app/AccessibilityStatement/page.tsx
@@ -1,0 +1,66 @@
+"use client"
+import Link from "next/link"
+
+export default function AccessibilityStatement() {
+  return (
+    <div className="max-w-3xl mx-auto py-12 px-4">
+      <h1 className="text-3xl font-bold mb-6 bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">
+        Accessibility Statement
+      </h1>
+
+      <p className="mb-4">
+        At <span className="font-semibold text-green-700">Verdant</span>, we are committed to ensuring that our environmental risk mapping tool is accessible to everyone, regardless of ability or technology.
+      </p>
+
+      <SectionTitle>Our Commitment</SectionTitle>
+      <p className="mb-4">
+        We strive to make our website and services usable by all people, including those with disabilities. Our goal is to conform to the <span className="font-semibold">Web Content Accessibility Guidelines (WCAG) 2.1</span> Level AA, and to continually improve the user experience for everyone.
+      </p>
+
+      <SectionTitle>Accessibility Features</SectionTitle>
+      <ul className="list-disc pl-6 mb-4">
+        <li>Semantic HTML for clear structure and navigation.</li>
+        <li>Keyboard navigability for all interactive elements.</li>
+        <li>High color contrast and readable font sizes.</li>
+        <li>Alt text for all meaningful images and icons.</li>
+        <li>Responsive design for use on all devices.</li>
+        <li>ARIA labels and roles where appropriate.</li>
+      </ul>
+
+      <SectionTitle>Ongoing Efforts</SectionTitle>
+      <p className="mb-4">
+        We regularly review our website and content to identify and address accessibility issues. We welcome feedback from users to help us improve.
+      </p>
+
+      <SectionTitle>Contact Us</SectionTitle>
+      <p className="mb-4">
+        If you experience any difficulty accessing content on <span className="font-semibold text-green-700">Verdant</span>, or have suggestions for improvement, please <Link href="/contact" className="underline text-blue-600 hover:text-green-600 transition-colors">contact us</Link>. We value your input and will do our best to address your concerns.
+      </p>
+
+      <SectionTitle>Third-Party Content</SectionTitle>
+      <p className="mb-4">
+        While we strive to ensure accessibility on all parts of our website, some third-party content or features may not fully meet our standards. We encourage you to let us know if you encounter any barriers.
+      </p>
+
+      <p className="text-sm text-gray-500 mt-8">
+        Last updated: April 15, 2025
+      </p>
+    </div>
+  )
+}
+
+// Same left border with logo colors functions as found under the privacy and terms pages
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2
+      className="text-2xl font-semibold mt-8 mb-2 pl-3 border-l-4"
+      style={{
+        borderImage: "linear-gradient(to bottom, #38bdf8, #4ade80) 1",
+        borderLeftWidth: 6,
+        borderLeftStyle: "solid"
+      }}
+    >
+      {children}
+    </h2>
+  )
+}

--- a/src/app/PrivacyPolicy/page.tsx
+++ b/src/app/PrivacyPolicy/page.tsx
@@ -1,0 +1,84 @@
+"use client"
+import Link from "next/link"
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="max-w-3xl mx-auto py-12 px-4">
+      <h1 className="text-3xl font-bold mb-6 bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">
+        Privacy Policy
+      </h1>
+
+      <p className="mb-4">
+        This Privacy Policy describes how <span className="font-semibold text-green-700">Verdant</span> collects, uses, and protects your information when you use our website and services.
+      </p>
+
+      <SectionTitle>Information We Collect</SectionTitle>
+      <ul className="list-disc pl-6 mb-4">
+        <li>
+          <span className="font-semibold">Personal Information:</span> We do not require you to provide personal information. However, if you contact us, sign up for updates, or create an account, we may collect your name and email address. The BETTER-AUTH authentication framework is used to securely manage emails, passwords, and accounts.
+        </li>
+        <li>
+          <span className="font-semibold">Usage Data:</span> We may collect non-personal information about how you interact with the Service, such as your IP address, browser type, device information, and pages visited. This helps us improve the Service.
+        </li>
+        <li>
+          <span className="font-semibold">Cookies:</span> We may use cookies or similar technologies to enhance your experience and analyze usage.
+        </li>
+      </ul>
+
+      <SectionTitle>How We Use Your Information</SectionTitle>
+      <ul className="list-disc pl-6 mb-4">
+        <li>To provide, operate, and improve the Service.</li>
+        <li>To respond to your inquiries or requests.</li>
+        <li>To analyze usage and trends to improve user experience.</li>
+        <li>To send updates or information if you have opted in.</li>
+      </ul>
+
+      <SectionTitle>Data Sharing and Disclosure</SectionTitle>
+      <ul className="list-disc pl-6 mb-4">
+        <li>We do not sell or rent your personal information.</li>
+        <li>We may share information with trusted service providers who assist us in operating the Service, subject to confidentiality agreements.</li>
+        <li>We may disclose information if required by law or to protect our rights and safety.</li>
+      </ul>
+
+      <SectionTitle>Data Security</SectionTitle>
+      <p className="mb-4">
+        We take reasonable measures to protect your information from unauthorized access, alteration, or disclosure. However, no method of transmission over the Internet or electronic storage is 100% secure.
+      </p>
+
+      <SectionTitle>Third-Party Links</SectionTitle>
+      <p className="mb-4">
+        Our Service contains links to third-party websites. We are not responsible for the privacy practices or content of those sites. Please review their privacy policies before providing any information.
+      </p>
+
+      <SectionTitle>Changes to This Policy</SectionTitle>
+      <p className="mb-4">
+        We may update this Privacy Policy from time to time. Changes will be posted on this page with an updated effective date. Your continued use of the Service constitutes acceptance of the revised policy.
+      </p>
+
+      <SectionTitle>Contact Us</SectionTitle>
+      <p className="mb-4">
+        If you have any questions or concerns about this Privacy Policy, please <Link href="/contact" className="underline text-blue-600 hover:text-green-600 transition-colors">contact us</Link>.
+      </p>
+
+      <p className="text-sm text-gray-500 mt-8">
+        Last updated: April 15, 2025
+      </p>
+    </div>
+  )
+}
+
+// Same function to generate the left border with logo colors, if we end up reusing in more areas could maybe move somewhere else
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2
+      className="text-2xl font-semibold mt-8 mb-2 pl-3 border-l-4"
+      style={{
+        borderImage: "linear-gradient(to bottom, #38bdf8, #4ade80) 1",
+        borderLeftWidth: 6,
+        borderLeftStyle: "solid"
+      }}
+    >
+      {children}
+    </h2>
+  )
+}

--- a/src/app/TermsandConditions/page.tsx
+++ b/src/app/TermsandConditions/page.tsx
@@ -1,0 +1,80 @@
+"use client"
+import Link from "next/link"
+
+export default function TermsAndConditions() {
+  return (
+    <div className="max-w-3xl mx-auto py-12 px-4">
+      {/* This is some styling I picked for a gradiant heading with the website logo colors, can be changed */}
+      <h1 className="text-3xl font-bold mb-6 bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">
+        Terms and Conditions
+      </h1>
+
+      <p className="mb-4">
+        Welcome to <span className="font-semibold text-green-700">Verdant</span>. By accessing or using this website, you agree to be bound by these Terms and Conditions. Please read them carefully.
+      </p>
+
+      <SectionTitle>Acceptance of Terms</SectionTitle>
+      <p className="mb-4">
+        By using this Service, you acknowledge that you have read, understood, and agree to be bound by these Terms and Conditions and our{" "}
+        <Link href="/PrivacyPolicy" className="underline text-blue-600 hover:text-green-600 transition-colors">Privacy Policy</Link>. If you do not agree, please do not use the Service.
+      </p>
+
+      <SectionTitle>Service Description</SectionTitle>
+      <p className="mb-4">
+        This Service provides environmental risk information, mapping, and related data for educational and informational purposes only. The data and results are provided "as is" and may not be complete or up-to-date.
+      </p>
+
+      <SectionTitle>No Professional Advice</SectionTitle>
+      <p className="mb-4">
+        The information provided by this Service does not constitute legal, financial, or professional advice. You should consult with appropriate professionals before making any decisions based on the information provided.
+      </p>
+
+      <SectionTitle>User Responsibilities</SectionTitle>
+      <ul className="list-disc pl-6 mb-4">
+        <li>You agree to use the Service only for lawful purposes.</li>
+        <li>You will not misuse, copy, or redistribute the data or content without permission.</li>
+        <li>You are responsible for any activity that occurs under your use of the Service.</li>
+      </ul>
+
+      <SectionTitle>Intellectual Property</SectionTitle>
+      <p className="mb-4">
+        All content, graphics, and code on this website are the property of Verdant or its licensors. Unauthorized use is prohibited.
+      </p>
+
+      <SectionTitle>Limitation of Liability</SectionTitle>
+      <p className="mb-4">
+        To the fullest extent permitted by law, Verdant and its affiliates are not liable for any damages or losses resulting from your use of the Service or reliance on its content.
+      </p>
+
+      <SectionTitle>Changes to Terms</SectionTitle>
+      <p className="mb-4">
+        We reserve the right to update or modify these Terms and Conditions at any time. Changes will be posted on this page. Continued use of the Service after changes constitutes acceptance of the new terms.
+      </p>
+
+      <SectionTitle>Contact</SectionTitle>
+      <p className="mb-4">
+        If you have any questions about these Terms and Conditions, please <Link href="/contact" className="underline text-blue-600 hover:text-green-600 transition-colors">contact us</Link>.
+      </p>
+
+      <p className="text-sm text-gray-500 mt-8">
+        Last updated: April 15, 2025
+      </p>
+    </div>
+  )
+}
+
+// Colored left border for section titles, uses the green/blue colors of our logo
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2
+      className="text-2xl font-semibold mt-8 mb-2 pl-3 border-l-4"
+      style={{
+        borderImage: "linear-gradient(to bottom, #38bdf8, #4ade80) 1",
+        borderLeftWidth: 6,
+        borderLeftStyle: "solid"
+      }}
+    >
+      {children}
+    </h2>
+  )
+}

--- a/src/components/layout/base/navigation-items.ts
+++ b/src/components/layout/base/navigation-items.ts
@@ -39,17 +39,17 @@ export const resourceComponents: ComponentListProps[] = [
 export const agreementComponents: ComponentListProps[] = [
   {
     title: "Terms and Conditions",
-    href: "/#",
+    href: "/TermsandConditions",
     description: "Read the terms and conditions for using our website"
   },
   {
     title: "Privacy Policy",
-    href: "/#",
+    href: "/PrivacyPolicy",
     description: "Learn how we handle and protect your personal information"
   },
   {
     title: "Accessibility Statement",
-    href: "/#",
+    href: "/AccessibilityStatement",
     description: "Find out how we ensure our website is accessible to everyone"
   }
 ]


### PR DESCRIPTION
Here are the three pages under the agreement tab. Its mostly generic, filled out by template info. Besides the template, I tried to incorporate some of the website logo colors through some gradient colors and a border for section titles. Below are some images of how this looks for the three pages (the photos don't contain the full page though, can look at files for included sections/information). If styling or content should be changed, please let me know. The pages also have a link to the contact us page once that is finished.
<img width="952" alt="termspic" src="https://github.com/user-attachments/assets/63136f01-b7a7-45e0-8aa7-97fca89f8d4d" />
<img width="929" alt="privacypolicypic" src="https://github.com/user-attachments/assets/0f3ba5f0-e44c-4405-a062-9fff005f1b18" />
<img width="953" alt="accessibilitystatementpic" src="https://github.com/user-attachments/assets/5ac8754d-8457-4dfe-b6a7-227a534656f4" />
